### PR TITLE
Fix/feed #62

### DIFF
--- a/src/main/java/com/codeit/otboo/domain/feed/dto/response/CommentDtoCursorResponse.java
+++ b/src/main/java/com/codeit/otboo/domain/feed/dto/response/CommentDtoCursorResponse.java
@@ -1,5 +1,6 @@
 package com.codeit.otboo.domain.feed.dto.response;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 
@@ -12,14 +13,14 @@ import lombok.NoArgsConstructor;
 public class CommentDtoCursorResponse {
 
 	private List<CommentDto> data;
-	private String nextCursor;
+	private Instant nextCursor;
 	private UUID nextIdAfter;
 	private boolean hasNext;
 	private long totalCount;
 	private String sortBy;
 	private String sortDirection;
 
-	public CommentDtoCursorResponse(List<CommentDto> data, String nextCursor, UUID nextIdAfter,
+	public CommentDtoCursorResponse(List<CommentDto> data, Instant nextCursor, UUID nextIdAfter,
 		boolean hasNext, long totalCount, String sortBy, String sortDirection) {
 		this.data = data;
 		this.nextCursor = nextCursor;

--- a/src/main/java/com/codeit/otboo/domain/feed/dto/response/FeedDto.java
+++ b/src/main/java/com/codeit/otboo/domain/feed/dto/response/FeedDto.java
@@ -1,10 +1,8 @@
 package com.codeit.otboo.domain.feed.dto.response;
 
-import com.codeit.otboo.domain.clothes.dto.response.ClothesAttributeDefDto;
 import com.codeit.otboo.domain.clothes.dto.response.ClothesAttributeWithDefDto;
 import com.codeit.otboo.domain.feed.entity.Feed;
 import com.codeit.otboo.domain.feed.entity.Ootd;
-import com.codeit.otboo.domain.feed.dto.response.OotdDto;
 import com.codeit.otboo.domain.user.entity.User;
 import com.codeit.otboo.domain.weather.dto.WeatherForFeedDto;
 import com.codeit.otboo.domain.weather.entity.Weather;
@@ -26,7 +24,7 @@ public record FeedDto(
 	boolean likedByMe
 ) {
 
-	public static FeedDto fromEntity(Feed feed) {
+	public static FeedDto fromEntity(Feed feed, boolean likedByMe) {
 		// Author
 		User authorEntity = feed.getUser();
 		AuthorDto authorDto = new AuthorDto(
@@ -43,7 +41,6 @@ public record FeedDto(
 			weatherEntity.getPrecipitation(),
 			weatherEntity.getTemperature()
 		);
-
 
 		// OOTDs
 		List<OotdDto> ootdList = feed.getClothesFeeds().stream()
@@ -63,6 +60,7 @@ public record FeedDto(
 					.toList()
 			))
 			.toList();
+		//check for this feed likedByMe
 
 		return new FeedDto(
 			feed.getId(),
@@ -74,7 +72,23 @@ public record FeedDto(
 			feed.getContent(),
 			feed.getLikeCount(),
 			feed.getCommentCount(),
-			feed.isLikedByMe()
+			likedByMe
+		);
+	}
+
+	public FeedDto withLikedByMe(boolean likedByMe) {
+		return new FeedDto(
+			this.id,
+			this.createdAt,
+			this.updatedAt,
+			this.author,
+			this.weather,
+			this.ootds,
+			this.content,
+			this.likeCount,
+			this.commentCount,
+			likedByMe
 		);
 	}
 }
+

--- a/src/main/java/com/codeit/otboo/domain/feed/entity/Feed.java
+++ b/src/main/java/com/codeit/otboo/domain/feed/entity/Feed.java
@@ -1,13 +1,8 @@
 package com.codeit.otboo.domain.feed.entity;
 
-import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import com.codeit.otboo.domain.clothes.entity.Clothes;
 import com.codeit.otboo.domain.user.entity.User;
@@ -17,11 +12,7 @@ import com.codeit.otboo.global.base.BaseUpdatableEntity;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
 import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;

--- a/src/main/java/com/codeit/otboo/domain/feed/entity/FeedComment.java
+++ b/src/main/java/com/codeit/otboo/domain/feed/entity/FeedComment.java
@@ -1,7 +1,5 @@
 package com.codeit.otboo.domain.feed.entity;
 
-import java.util.UUID;
-
 import com.codeit.otboo.domain.user.entity.User;
 import com.codeit.otboo.global.base.BaseEntity;
 

--- a/src/main/java/com/codeit/otboo/domain/feed/entity/FeedLike.java
+++ b/src/main/java/com/codeit/otboo/domain/feed/entity/FeedLike.java
@@ -1,6 +1,5 @@
 package com.codeit.otboo.domain.feed.entity;
 
-import java.util.UUID;
 
 import com.codeit.otboo.domain.user.entity.User;
 import com.codeit.otboo.global.base.BaseEntity;

--- a/src/main/java/com/codeit/otboo/domain/feed/entity/Ootd.java
+++ b/src/main/java/com/codeit/otboo/domain/feed/entity/Ootd.java
@@ -1,7 +1,5 @@
 package com.codeit.otboo.domain.feed.entity;
 
-import java.util.UUID;
-
 import com.codeit.otboo.domain.clothes.entity.Clothes;
 import com.codeit.otboo.global.base.BaseEntity;
 

--- a/src/main/java/com/codeit/otboo/domain/feed/repository/FeedCommentRepository.java
+++ b/src/main/java/com/codeit/otboo/domain/feed/repository/FeedCommentRepository.java
@@ -1,41 +1,12 @@
 package com.codeit.otboo.domain.feed.repository;
 
-import java.time.Instant;
-import java.util.List;
 import java.util.UUID;
 
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import com.codeit.otboo.domain.feed.entity.FeedComment;
 
-public interface FeedCommentRepository extends JpaRepository<FeedComment, UUID> {
-
-	@Query("""
-      SELECT c
-      FROM FeedComment c
-      JOIN FETCH c.author u
-      WHERE c.feed.id = :feedId
-        AND ( :cursor IS NULL
-              OR (c.createdAt < :cursor
-                  OR (c.createdAt = :cursor AND c.id < :idAfter))
-            )
-      ORDER BY c.createdAt DESC, c.id DESC
-      """)
-	List<FeedComment> findCommentsByCreatedAtCursor(
-		@Param("feedId") UUID feedId,
-		@Param("cursor") Instant cursor,
-		@Param("idAfter") UUID idAfter,
-		Pageable pageable
-	);
-
-	@Query("""
-      SELECT COUNT(c)
-      FROM FeedComment c
-      WHERE c.feed.id = :feedId
-      """)
-	long countByFeedId(
-		@Param("feedId") UUID feedId
-	);
+public interface FeedCommentRepository
+	extends JpaRepository<FeedComment, UUID>,
+	FeedCommentRepositoryCustom {
+	long countByFeedId(UUID feedId);
 }

--- a/src/main/java/com/codeit/otboo/domain/feed/repository/FeedCommentRepositoryCustom.java
+++ b/src/main/java/com/codeit/otboo/domain/feed/repository/FeedCommentRepositoryCustom.java
@@ -1,0 +1,16 @@
+package com.codeit.otboo.domain.feed.repository;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import com.codeit.otboo.domain.feed.entity.FeedComment;
+
+public interface FeedCommentRepositoryCustom {
+	List<FeedComment> findByFeedIdCursor(
+		UUID feedId,
+		Instant cursor,
+		UUID idAfter,
+		int limit
+	);
+}

--- a/src/main/java/com/codeit/otboo/domain/feed/repository/FeedCommentRepositoryImpl.java
+++ b/src/main/java/com/codeit/otboo/domain/feed/repository/FeedCommentRepositoryImpl.java
@@ -1,0 +1,55 @@
+package com.codeit.otboo.domain.feed.repository;
+
+import static com.codeit.otboo.domain.feed.entity.QFeedComment.*;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.stereotype.Repository;
+
+import com.codeit.otboo.domain.feed.entity.FeedComment;
+import com.codeit.otboo.domain.user.entity.QUser;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import jakarta.persistence.EntityManager;
+
+@Repository
+public class FeedCommentRepositoryImpl implements FeedCommentRepositoryCustom {
+
+	private final JPAQueryFactory queryFactory;
+	private final QUser author = QUser.user;
+
+	public FeedCommentRepositoryImpl(EntityManager em) {
+		this.queryFactory = new JPAQueryFactory(em);
+	}
+
+	@Override
+	public List<FeedComment> findByFeedIdCursor(
+		UUID feedId,
+		Instant cursor,
+		UUID idAfter,
+		int limit
+	) {
+		BooleanBuilder where = new BooleanBuilder();
+		where.and(feedComment.feed.id.eq(feedId));
+
+		if (cursor != null) {
+			// (c.createdAt < cursor) OR (c.createdAt = cursor AND c.id < idAfter)
+			where.and(
+				feedComment.createdAt.lt(cursor)
+					.or(feedComment.createdAt.eq(cursor)
+						.and(feedComment.id.lt(idAfter)))
+			);
+		}
+
+		return queryFactory
+			.selectFrom(feedComment)
+			.join(feedComment.author, author).fetchJoin()
+			.where(where)
+			.orderBy(feedComment.createdAt.desc(), feedComment.id.desc())
+			.limit(limit)
+			.fetch();
+	}
+}

--- a/src/main/java/com/codeit/otboo/domain/feed/repository/FeedLikeRepository.java
+++ b/src/main/java/com/codeit/otboo/domain/feed/repository/FeedLikeRepository.java
@@ -1,5 +1,6 @@
 package com.codeit.otboo.domain.feed.repository;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -13,4 +14,6 @@ public interface FeedLikeRepository extends JpaRepository<FeedLike, UUID> {
 	List<FeedLike> findAllByUserIdAndFeedIdIn(UUID userId, List<UUID> feedIds);
 	List<FeedLike> findAllByFeedId(UUID feedId);
 	Optional<FeedLike> findByFeedAndUser(Feed feed, User user);
+	List<FeedLike> findByUserIdAndFeedIdIn(UUID userId, Collection<UUID> feedIds);
+	boolean existsByUserIdAndFeedId(UUID userId, UUID feedId);
 }

--- a/src/main/java/com/codeit/otboo/domain/feed/repository/FeedRepository.java
+++ b/src/main/java/com/codeit/otboo/domain/feed/repository/FeedRepository.java
@@ -1,93 +1,13 @@
 package com.codeit.otboo.domain.feed.repository;
 
-import java.time.Instant;
-import java.util.List;
 import java.util.UUID;
 
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.codeit.otboo.domain.feed.entity.Feed;
-import com.codeit.otboo.domain.weather.entity.vo.PrecipitationType;
-import com.codeit.otboo.domain.weather.entity.vo.SkyStatus;
 
 @Repository
-public interface FeedRepository extends JpaRepository<Feed, UUID> {
-
-	/** 생성일순 커서 페이징 + 필터(대소문자 구분 없이 keyword) */
-	@Query("""
-      SELECT f
-      FROM Feed f
-      JOIN FETCH f.user u
-      JOIN FETCH f.weather w
-      WHERE (:keywordLike          IS NULL
-             OR LOWER(f.content) LIKE LOWER(CONCAT('%', :keywordLike, '%')))
-        AND (:skyStatusEqual       IS NULL
-             OR w.skyStatus      = :skyStatusEqual)
-        AND (:precipitationTypeEq  IS NULL
-             OR w.precipitationType = :precipitationTypeEq)
-        AND (
-             :cursorCreatedAt IS NULL
-          OR (f.createdAt < :cursorCreatedAt
-           OR (f.createdAt = :cursorCreatedAt AND f.id < :cursorId))
-        )
-      ORDER BY f.createdAt DESC, f.id DESC
-      """)
-	List<Feed> findFeedsByCreatedAtCursor(
-		@Param("keywordLike")           String keywordLike,
-		@Param("skyStatusEqual")        SkyStatus skyStatusEqual,
-		@Param("precipitationTypeEq")   PrecipitationType precipitationTypeEq,
-		@Param("cursorCreatedAt")       Instant cursorCreatedAt,
-		@Param("cursorId")              UUID cursorId,
-		Pageable pageable
-	);
-
-	/** 좋아요순 커서 페이징 + 동일 필터 */
-	@Query("""
-      SELECT f
-      FROM Feed f
-      JOIN FETCH f.user u
-      JOIN FETCH f.weather w
-      WHERE (:keywordLike          IS NULL
-             OR LOWER(f.content) LIKE LOWER(CONCAT('%', :keywordLike, '%')))
-        AND (:skyStatusEqual       IS NULL
-             OR w.skyStatus      = :skyStatusEqual)
-        AND (:precipitationTypeEq  IS NULL
-             OR w.precipitationType = :precipitationTypeEq)
-        AND (
-             :cursorLikeCount IS NULL
-          OR (f.likeCount < :cursorLikeCount
-           OR (f.likeCount = :cursorLikeCount AND f.id < :cursorId))
-        )
-      ORDER BY f.likeCount DESC, f.id DESC
-      """)
-	List<Feed> findFeedsByLikeCountCursor(
-		@Param("keywordLike")           String keywordLike,
-		@Param("skyStatusEqual")        SkyStatus skyStatusEqual,
-		@Param("precipitationTypeEq")   PrecipitationType precipitationTypeEq,
-		@Param("cursorLikeCount")       Long cursorLikeCount,
-		@Param("cursorId")              UUID cursorId,
-		Pageable pageable
-	);
-
-	/** 전체 개수 조회용 (필터만 적용) */
-	@Query("""
-      SELECT COUNT(f)
-      FROM Feed f
-      JOIN f.weather w
-      WHERE (:keywordLike          IS NULL
-             OR LOWER(f.content) LIKE LOWER(CONCAT('%', :keywordLike, '%')))
-        AND (:skyStatusEqual       IS NULL
-             OR w.skyStatus      = :skyStatusEqual)
-        AND (:precipitationTypeEq  IS NULL
-             OR w.precipitationType = :precipitationTypeEq)
-      """)
-	long countByFilters(
-		@Param("keywordLike")           String keywordLike,
-		@Param("skyStatusEqual")        SkyStatus skyStatusEqual,
-		@Param("precipitationTypeEq")   PrecipitationType precipitationTypeEq
-	);
+public interface FeedRepository
+	extends JpaRepository<Feed, UUID>, FeedRepositoryCustom {
 }

--- a/src/main/java/com/codeit/otboo/domain/feed/repository/FeedRepositoryCustom.java
+++ b/src/main/java/com/codeit/otboo/domain/feed/repository/FeedRepositoryCustom.java
@@ -1,0 +1,35 @@
+package com.codeit.otboo.domain.feed.repository;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import com.codeit.otboo.domain.feed.entity.Feed;
+import com.codeit.otboo.domain.weather.entity.vo.PrecipitationType;
+import com.codeit.otboo.domain.weather.entity.vo.SkyStatus;
+
+public interface FeedRepositoryCustom {
+	List<Feed> findByCreatedAtCursor(
+		String keyword,
+		SkyStatus skyStatus,
+		PrecipitationType precipitationType,
+		Instant cursorCreatedAt,
+		UUID cursorId,
+		int limit
+	);
+
+	List<Feed> findByLikeCountCursor(
+		String keyword,
+		SkyStatus skyStatus,
+		PrecipitationType precipitationType,
+		Long cursorLikeCount,
+		UUID cursorId,
+		int limit
+	);
+
+	long countByFilters(
+		String keyword,
+		SkyStatus skyStatus,
+		PrecipitationType precipitationType
+	);
+}

--- a/src/main/java/com/codeit/otboo/domain/feed/repository/FeedRepositoryImpl.java
+++ b/src/main/java/com/codeit/otboo/domain/feed/repository/FeedRepositoryImpl.java
@@ -1,0 +1,141 @@
+package com.codeit.otboo.domain.feed.repository;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.stereotype.Repository;
+
+import com.codeit.otboo.domain.feed.entity.Feed;
+import com.codeit.otboo.domain.feed.entity.QFeed;
+import com.codeit.otboo.domain.user.entity.QUser;
+import com.codeit.otboo.domain.weather.entity.QWeather;
+import com.codeit.otboo.domain.weather.entity.vo.PrecipitationType;
+import com.codeit.otboo.domain.weather.entity.vo.SkyStatus;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import jakarta.persistence.EntityManager;
+
+@Repository
+public class FeedRepositoryImpl implements FeedRepositoryCustom {
+
+	private final JPAQueryFactory query;
+	private final QFeed feed    = QFeed.feed;
+	private final QUser user    = QUser.user;
+	private final QWeather weather = QWeather.weather;
+
+	public FeedRepositoryImpl(EntityManager em) {
+		this.query = new JPAQueryFactory(em);
+	}
+
+	@Override
+	public List<Feed> findByCreatedAtCursor(
+		String keyword,
+		SkyStatus skyStatus,
+		PrecipitationType precipitationType,
+		Instant cursorCreatedAt,
+		UUID cursorId,
+		int limit
+	) {
+		BooleanBuilder where = new BooleanBuilder();
+
+		if (keyword != null && !keyword.isBlank()) {
+			where.and(feed.content.containsIgnoreCase(keyword));
+		}
+		if (skyStatus != null) {
+			where.and(feed.weather.skyStatus.eq(skyStatus));
+		}
+		if (precipitationType != null) {
+			where.and(feed.weather.precipitationType.eq(precipitationType));
+		}
+		if (cursorCreatedAt != null && cursorId != null) {
+			where.and(
+				feed.createdAt.lt(cursorCreatedAt)
+					.or(feed.createdAt.eq(cursorCreatedAt)
+						.and(feed.id.lt(cursorId)))
+			);
+		}
+
+		return query
+			.selectFrom(feed)
+			.join(feed.user, user).fetchJoin()
+			.join(feed.weather, weather).fetchJoin()
+			.where(where)
+			.orderBy(
+				new OrderSpecifier<>(Order.DESC, feed.createdAt),
+				new OrderSpecifier<>(Order.DESC, feed.id)
+			)
+			.limit(limit)
+			.fetch();
+	}
+
+	@Override
+	public List<Feed> findByLikeCountCursor(
+		String keyword,
+		SkyStatus skyStatus,
+		PrecipitationType precipitationType,
+		Long cursorLikeCount,
+		UUID cursorId,
+		int limit
+	) {
+		BooleanBuilder where = new BooleanBuilder();
+
+		if (keyword != null && !keyword.isBlank()) {
+			where.and(feed.content.containsIgnoreCase(keyword));
+		}
+		if (skyStatus != null) {
+			where.and(feed.weather.skyStatus.eq(skyStatus));
+		}
+		if (precipitationType != null) {
+			where.and(feed.weather.precipitationType.eq(precipitationType));
+		}
+		if (cursorLikeCount != null && cursorId != null) {
+			where.and(
+				feed.likeCount.lt(cursorLikeCount)
+					.or(feed.likeCount.eq(cursorLikeCount)
+						.and(feed.id.lt(cursorId)))
+			);
+		}
+
+		return query
+			.selectFrom(feed)
+			.join(feed.user, user).fetchJoin()
+			.join(feed.weather, weather).fetchJoin()
+			.where(where)
+			.orderBy(
+				new OrderSpecifier<>(Order.DESC, feed.likeCount),
+				new OrderSpecifier<>(Order.DESC, feed.id)
+			)
+			.limit(limit)
+			.fetch();
+	}
+
+	@Override
+	public long countByFilters(
+		String keyword,
+		SkyStatus skyStatus,
+		PrecipitationType precipitationType
+	) {
+		BooleanBuilder where = new BooleanBuilder();
+
+		if (keyword != null && !keyword.isBlank()) {
+			where.and(feed.content.containsIgnoreCase(keyword));
+		}
+		if (skyStatus != null) {
+			where.and(feed.weather.skyStatus.eq(skyStatus));
+		}
+		if (precipitationType != null) {
+			where.and(feed.weather.precipitationType.eq(precipitationType));
+		}
+
+		return query
+			.select(feed.count())
+			.from(feed)
+			.join(feed.weather, weather)
+			.where(where)
+			.fetchOne();
+	}
+}

--- a/src/main/java/com/codeit/otboo/domain/feed/service/impl/FeedLikeServiceImpl.java
+++ b/src/main/java/com/codeit/otboo/domain/feed/service/impl/FeedLikeServiceImpl.java
@@ -15,7 +15,6 @@ import com.codeit.otboo.domain.feed.service.FeedLikeService;
 import com.codeit.otboo.domain.user.entity.User;
 import com.codeit.otboo.domain.user.repository.UserRepository;
 import com.codeit.otboo.exception.CustomException;
-import com.codeit.otboo.global.error.ErrorCode;
 
 import lombok.RequiredArgsConstructor;
 
@@ -31,13 +30,13 @@ public class FeedLikeServiceImpl implements FeedLikeService {
 	@Override
 	public void likeFeed(UUID myUSerId, UUID feedId) {
 		User user = userRepository.findById(myUSerId)
-			.orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+			.orElseThrow(() -> new CustomException(USER_NOT_FOUND)); //좋아요 찍은 사람
 
 		Feed feed = feedRepository.findById(feedId)
 			.orElseThrow(() -> new CustomException(FEED_NOT_FOUND));
 
 		if (feedLikeRepository.existsByFeedAndUser(feed, user)) {
-			throw new CustomException(FEED_LIKE_ALREADY);
+			throw new CustomException(FEED_LIKE_ALREADY); //피드 좋아요 레포 : 피드와 좋아요를 찍은 사람레포. 이미 있으면 말이 안되는 상황
 		}
 
 		FeedLike feedLike = new FeedLike(feed, user);

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -90,7 +90,7 @@ CREATE TABLE weathers (
                           location JSON,                      -- 위치
                           sky_status VARCHAR(255) NOT NULL,   -- 하늘상태
                           precipitation JSON,
-                          precipitation_type VARCHAR(32)      -- 강수정보
+                          precipitation_type VARCHAR(32),      -- 강수정보
                           humidity JSON,                      -- 습도
                           temperature JSON,                   -- 온도
                           wind_speed JSON,                    -- 풍속

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -6,7 +6,7 @@ spring:
     driver-class-name: org.postgresql.Driver
   sql:
     init:
-      mode: always
+      mode: never
       schema-locations: classpath:schema.sql
       # data-locations: classpath:data.sql
   jpa:


### PR DESCRIPTION
## 🧩 이슈 번호 

  -close #62 


## ✅ 작업 사항
사실 쿼리 dsl 없이 순수쿼리로 밀어보고싶었는데 계속해서 쿼리에서 에러가 터져서 어쩔 수 없이 쿼리 dsl을 적용해서 피드파트(피드, 댓글) 구현을 완료했습니다.
또한, 기존 likedByMe의 로직을 이상하게 작성하여, 이제 해당 피드, 사용자(Bearer토큰) 을 이용하여, FEEDLIKE 테이블을 순회하며 likedByMe 조건이 만족할 때 진리값을 선택하도록 수정하였습니다. 

## 💬 기타 사항
고도화 단계 적용 시, 알림, 알림이 중복해서 계속 call 되는 상황, feedLike 테이블 순회 시 인덱스 적용을 통한 풀스캔 방지 등 개선할 부분이 남아있습니다
