### PR TITLE
Refactor: 날씨 데이터 수집 및 조회 로직 전면 개선

### DIFF
--- a/src/main/java/com/codeit/otboo/domain/feed/service/impl/FeedServiceImpl.java
+++ b/src/main/java/com/codeit/otboo/domain/feed/service/impl/FeedServiceImpl.java
@@ -82,7 +82,7 @@ public class FeedServiceImpl implements FeedService {
 				throw new CustomException(LOCATION_NOT_SET);
 			}
 
-			weather = weatherRepository.findLatestForecastByLocation(x, y, OffsetDateTime.now())
+			weather = weatherRepository.findLatestWeatherByLocation(x, y)
 					.orElseThrow(() -> new CustomException(WEATHER_NOT_FOUND_FOR_LOCATION));
 		}
 

--- a/src/main/java/com/codeit/otboo/domain/recommendation/service/RecommendationService.java
+++ b/src/main/java/com/codeit/otboo/domain/recommendation/service/RecommendationService.java
@@ -56,7 +56,7 @@ public class RecommendationService {
 				throw new CustomException(ErrorCode.LOCATION_NOT_SET);
 			}
 
-			weather = weatherRepository.findLatestForecastByLocation(x, y, OffsetDateTime.now())
+			weather = weatherRepository.findLatestWeatherByLocation(x, y)
 					.orElseThrow(() -> new CustomException(ErrorCode.WEATHER_NOT_FOUND_FOR_LOCATION));
 		}
 

--- a/src/main/java/com/codeit/otboo/domain/weather/batch/WeatherBatchConfig.java
+++ b/src/main/java/com/codeit/otboo/domain/weather/batch/WeatherBatchConfig.java
@@ -1,19 +1,18 @@
 package com.codeit.otboo.domain.weather.batch;
 
+import com.codeit.otboo.domain.user.entity.Profile;
 import com.codeit.otboo.domain.user.repository.ProfileRepository;
 import com.codeit.otboo.domain.weather.component.KmaApiClient;
 import com.codeit.otboo.domain.weather.component.WeatherParser;
-import com.codeit.otboo.domain.weather.dto.WeatherDto;
+import com.codeit.otboo.domain.weather.dto.KmaWeatherResponse;
 import com.codeit.otboo.domain.weather.entity.Weather;
-import com.codeit.otboo.domain.weather.entity.vo.LocationInfo;
+import com.codeit.otboo.domain.weather.entity.vo.*;
 import com.codeit.otboo.domain.weather.repository.WeatherRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.batch.core.Job;
-import org.springframework.batch.core.JobParameters;
-import org.springframework.batch.core.JobParametersBuilder;
-import org.springframework.batch.core.Step;
+import org.springframework.batch.core.*;
 import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
+import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.core.job.builder.JobBuilder;
 import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.batch.core.repository.JobRepository;
@@ -28,13 +27,22 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.transaction.PlatformTransactionManager;
 
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Slf4j
 @Configuration
 @EnableBatchProcessing
-@EnableScheduling      // 스케줄링 기능 활성화
+@EnableScheduling
 @RequiredArgsConstructor
 public class WeatherBatchConfig {
 
@@ -44,9 +52,8 @@ public class WeatherBatchConfig {
     private final JobRepository jobRepository;
     private final ProfileRepository profileRepository;
     private final PlatformTransactionManager transactionManager;
-    private final JobLauncher jobLauncher; // 스케줄러에서 Job을 실행시키기 위해 주입받습니다.
+    private final JobLauncher jobLauncher;
 
-    // 1. 날씨 수집 Job 정의
     @Bean
     public Job fetchWeatherJob() {
         return new JobBuilder("fetchWeatherJob", jobRepository)
@@ -54,7 +61,6 @@ public class WeatherBatchConfig {
                 .build();
     }
 
-    // 2. 날씨 수집 Step 정의
     @Bean
     public Step fetchWeatherStep() {
         return new StepBuilder("fetchWeatherStep", jobRepository)
@@ -65,59 +71,122 @@ public class WeatherBatchConfig {
                 .build();
     }
 
-    // 3. ItemReader 구현
     @Bean
+    @StepScope
     public ItemReader<LocationInfo> locationInfoItemReader() {
-        List<LocationInfo> locations = profileRepository.findAll().stream()
+        // (x, y) 좌표 기준으로 중복 위치를 제거
+        Collection<Profile> distinctProfiles = profileRepository.findAll().stream()
+                .filter(p -> p.getX() != null && p.getY() != null)
+                .collect(Collectors.toMap(
+                        p -> p.getX() + "," + p.getY(),
+                        p -> p,
+                        (p1, p2) -> p1
+                )).values();
+
+        List<LocationInfo> locations = distinctProfiles.stream()
                 .map(p -> new LocationInfo(p.getLatitude(), p.getLongitude(), p.getX(), p.getY()))
                 .collect(Collectors.toList());
+
+        log.info("Found {} unique and valid locations to fetch weather for.", locations.size());
         return new ListItemReader<>(locations);
     }
-    // 4. ItemProcessor 구현
+
     @Bean
+    @StepScope
     public ItemProcessor<LocationInfo, List<Weather>> weatherItemProcessor() {
         return locationInfo -> {
             String rawData = kmaApiClient.fetchWeatherForecast(locationInfo.x(), locationInfo.y());
-            List<WeatherDto> dtoList = weatherParser.parseAndGroup(rawData, locationInfo.latitude(), locationInfo.longitude());
+            List<KmaWeatherResponse.Item> items = weatherParser.parse(rawData);
+            if (items.isEmpty()) return null;
 
-            return dtoList.stream()
-                    .map(dto -> Weather.builder()
-                            .forecastedAt(dto.forecastedAt())
-                            .forecastAt(dto.forecastAt())
-                            .location(dto.location())
-                            .temperature(dto.temperature())
-                            .skyStatus(dto.skyStatus())
-                            .precipitation(dto.precipitation())
-                            .humidity(dto.humidity())
-                            .windSpeed(dto.windSpeed())
-                            .precipitationType(dto.precipitationType()) // ★ 추가!
-                            .build())
-                    .collect(Collectors.toList());
+            Map<String, List<KmaWeatherResponse.Item>> itemsByDate = items.stream()
+                    .collect(Collectors.groupingBy(KmaWeatherResponse.Item::getFcstDate));
+
+            List<String> sortedDates = new ArrayList<>(itemsByDate.keySet());
+            Collections.sort(sortedDates);
+
+            List<Weather> dailySummaries = new ArrayList<>();
+            Optional<Weather> yesterdayWeatherOpt = weatherRepository.findLatestWeatherByLocation(locationInfo.x(), locationInfo.y());
+
+            Double prevDayMaxTemp = yesterdayWeatherOpt.map(w -> w.getTemperature().max()).orElse(null);
+            Double prevDayHumidity = yesterdayWeatherOpt.map(w -> w.getHumidity().current()).orElse(null);
+
+            for (String forecastDateStr : sortedDates) {
+                List<KmaWeatherResponse.Item> dailyItems = itemsByDate.get(forecastDateStr);
+                Map<String, String> dailyValues = dailyItems.stream()
+                        .collect(Collectors.toMap(
+                                KmaWeatherResponse.Item::getCategory,
+                                KmaWeatherResponse.Item::getFcstValue,
+                                (v1, v2) -> v1
+                        ));
+
+                double minTemp = parseKmaDouble(dailyValues.get("TMN"));
+                double maxTemp = parseKmaDouble(dailyValues.get("TMX"));
+                if (minTemp == 0.0 && maxTemp != 0.0) { minTemp = maxTemp; } // 최저/최고 둘 중 하나만 없을 때 보정
+                if (maxTemp == 0.0 && minTemp != 0.0) { maxTemp = minTemp; }
+
+                if (minTemp == 0.0 && maxTemp == 0.0) {
+                    minTemp = dailyItems.stream().filter(it -> "TMP".equals(it.getCategory())).mapToDouble(it -> parseKmaDouble(it.getFcstValue())).min().orElse(0.0);
+                    maxTemp = dailyItems.stream().filter(it -> "TMP".equals(it.getCategory())).mapToDouble(it -> parseKmaDouble(it.getFcstValue())).max().orElse(0.0);
+                }
+
+                double currentTemp = parseKmaDouble(dailyValues.getOrDefault("TMP", String.valueOf(maxTemp)));
+                double currentHumidity = parseKmaDouble(dailyValues.get("REH"));
+
+                double tempDiff = 0.0;
+                double humDiff = 0.0;
+                if (prevDayMaxTemp != null && maxTemp != 0.0) {
+                    tempDiff = maxTemp - prevDayMaxTemp;
+                }
+                if (prevDayHumidity != null && currentHumidity != 0.0) {
+                    humDiff = currentHumidity - prevDayHumidity;
+                }
+
+                TemperatureInfo tempInfo = new TemperatureInfo(currentTemp, minTemp, maxTemp, tempDiff);
+                HumidityInfo humidityInfo = new HumidityInfo(currentHumidity, humDiff); // ✨ 버그 수정!
+
+                PrecipitationType pty = mapToPrecipitationType(dailyValues.getOrDefault("PTY", "0"));
+                SkyStatus sky = mapToSkyStatus(dailyValues.getOrDefault("SKY", "1"));
+                double pcp = parseKmaDouble(dailyValues.get("PCP"));
+                double pop = parseKmaDouble(dailyValues.get("POP"));
+                double wsd = parseKmaDouble(dailyValues.get("WSD"));
+
+                LocalDate forecastDate = LocalDate.parse(forecastDateStr, DateTimeFormatter.ofPattern("yyyyMMdd"));
+
+                Weather dailyWeather = Weather.builder()
+                        .location(locationInfo)
+                        .temperature(tempInfo)
+                        .humidity(humidityInfo)
+                        .skyStatus(sky)
+                        .precipitation(new PrecipitationInfo(pty, pcp, pop))
+                        .windSpeed(new WindSpeedInfo(wsd, mapToWindSpeedAsWord(wsd)))
+                        .precipitationType(pty)
+                        .forecastedAt(Instant.now())
+                        .forecastAt(forecastDate.atStartOfDay(ZoneId.of("Asia/Seoul")).toInstant())
+                        .build();
+
+                dailySummaries.add(dailyWeather);
+
+                if (maxTemp != 0.0) prevDayMaxTemp = maxTemp;
+                if (currentHumidity != 0.0) prevDayHumidity = currentHumidity;
+            }
+            return dailySummaries;
         };
     }
-
-    // 5. ItemWriter 구현
     @Bean
     public ItemWriter<List<Weather>> weatherListItemWriter() {
         return chunk -> {
             List<Weather> weathersToSave = chunk.getItems().stream()
                     .flatMap(List::stream)
                     .collect(Collectors.toList());
-
             log.info("Saving {} weather entities to the database.", weathersToSave.size());
             weatherRepository.saveAll(weathersToSave);
         };
     }
 
-    /**
-     * 주기적으로 날씨 수집 Job을 실행하는 스케줄러입니다.
-     * cron: 기상청 단기예보가 발표되는 매 3시간 주기의 10분 후 (02:10, 05:10, ...)에 실행됩니다.
-     * zone: 한국 시간대를 기준으로 동작합니다.
-     */
     @Scheduled(cron = "0 10 2,5,8,11,14,17,20,23 * * *", zone = "Asia/Seoul")
     public void runFetchWeatherJob() {
         try {
-            // 매번 다른 Job Instance를 생성하기 위해 현재 시간을 파라미터로 넘깁니다.
             JobParameters params = new JobParametersBuilder()
                     .addString("scheduledTime", String.valueOf(System.currentTimeMillis()))
                     .toJobParameters();
@@ -126,5 +195,48 @@ public class WeatherBatchConfig {
         } catch (Exception e) {
             log.error("Failed to run scheduled weather fetch job", e);
         }
+    }
+
+    // --- Helper Methods ---
+    private double parseKmaDouble(String value) {
+        if (value == null || value.contains("없음")) {
+            return 0.0;
+        }
+        String numericValue = value.replaceAll("[^\\d.-]", "");
+        if (numericValue.isEmpty() || "-".equals(numericValue)) {
+            return 0.0;
+        }
+        try {
+            return Double.parseDouble(numericValue);
+        } catch (NumberFormatException e) {
+            log.warn("Could not parse KMA double value: '{}'", value);
+            return 0.0;
+        }
+    }
+
+    private SkyStatus mapToSkyStatus(String skyCode) {
+        return switch (skyCode) {
+            case "1" -> SkyStatus.CLEAR;
+            case "3" -> SkyStatus.MOSTLY_CLOUDY;
+            case "4" -> SkyStatus.CLOUDY;
+            default -> SkyStatus.CLEAR;
+        };
+    }
+
+    private PrecipitationType mapToPrecipitationType(String ptyCode) {
+        return switch (ptyCode) {
+            case "1" -> PrecipitationType.RAIN;
+            case "2" -> PrecipitationType.RAIN_SNOW;
+            case "3" -> PrecipitationType.SNOW;
+            case "4" -> PrecipitationType.SHOWER;
+            default -> PrecipitationType.NONE;
+        };
+    }
+
+    private String mapToWindSpeedAsWord(double speed) {
+        if (speed < 4) return "약함";
+        if (speed < 9) return "약간 강함";
+        if (speed < 14) return "강함";
+        return "매우 강함";
     }
 }

--- a/src/main/java/com/codeit/otboo/domain/weather/component/WeatherParser.java
+++ b/src/main/java/com/codeit/otboo/domain/weather/component/WeatherParser.java
@@ -1,25 +1,14 @@
 package com.codeit.otboo.domain.weather.component;
 
 import com.codeit.otboo.domain.weather.dto.KmaWeatherResponse;
-import com.codeit.otboo.domain.weather.dto.WeatherDto;
-import com.codeit.otboo.domain.weather.entity.vo.*;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
-import java.time.Instant;
-import java.time.LocalDate;
-import java.time.LocalTime;
-import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
-import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-import java.util.stream.Collectors;
 
 @Component
 @Slf4j
@@ -28,7 +17,12 @@ public class WeatherParser {
 
     private final ObjectMapper objectMapper;
 
-    public List<WeatherDto> parseAndGroup(String jsonString, double latitude, double longitude) {
+    /**
+     * KMA API 응답 문자열을 파싱하여 예보 Item 리스트를 반환합니다.
+     * @param jsonString 원본 JSON 응답
+     * @return 예보 Item 리스트
+     */
+    public List<KmaWeatherResponse.Item> parse(String jsonString) {
         try {
             KmaWeatherResponse response = objectMapper.readValue(jsonString, KmaWeatherResponse.class);
 
@@ -37,108 +31,11 @@ public class WeatherParser {
                 log.warn("KMA API response body or items are null. Raw Response: {}", jsonString);
                 return Collections.emptyList();
             }
-
-            Map<String, List<KmaWeatherResponse.Item>> groupedByDateTime =
-                    response.getResponse().getBody().getItems().getItemList().stream()
-                            .collect(Collectors.groupingBy(item -> item.getFcstDate() + item.getFcstTime()));
-
-            return groupedByDateTime.values().stream()
-                    .map(group -> createWeatherDtoFromGroup(group, latitude, longitude))
-                    .collect(Collectors.toList());
+            return response.getResponse().getBody().getItems().getItemList();
 
         } catch (JsonProcessingException e) {
-            log.error("Failed to parse KMA API response. The response is likely not JSON. Raw Response: {}", jsonString);
+            log.error("Failed to parse KMA API response. Raw Response: {}", jsonString, e);
             return Collections.emptyList();
         }
-    }
-
-    private WeatherDto createWeatherDtoFromGroup(List<KmaWeatherResponse.Item> items, double latitude, double longitude) {
-        Map<String, String> categoryValueMap = items.stream()
-                .collect(Collectors.toMap(KmaWeatherResponse.Item::getCategory, KmaWeatherResponse.Item::getFcstValue, (v1, v2) -> v1));
-
-        KmaWeatherResponse.Item firstItem = items.get(0);
-
-        LocationInfo location = new LocationInfo(latitude, longitude, firstItem.getNx(), firstItem.getNy());
-
-        TemperatureInfo temperature = new TemperatureInfo(
-                parseDouble(categoryValueMap.get("TMP")),
-                parseDouble(categoryValueMap.get("TMN")),
-                parseDouble(categoryValueMap.get("TMX")),
-                0.0
-        );
-
-        PrecipitationInfo precipitation = new PrecipitationInfo(
-                mapToPrecipitationType(categoryValueMap.getOrDefault("PTY", "0")),
-                parseDouble(categoryValueMap.get("PCP")),
-                parseDouble(categoryValueMap.get("POP"))
-        );
-
-        HumidityInfo humidity = new HumidityInfo(
-                parseDouble(categoryValueMap.get("REH")),
-                0.0
-        );
-
-        WindSpeedInfo windSpeed = new WindSpeedInfo(
-                parseDouble(categoryValueMap.get("WSD")),
-                mapToWindSpeedAsWord(parseDouble(categoryValueMap.get("WSD")))
-        );
-
-        SkyStatus skyStatus = mapToSkyStatus(categoryValueMap.getOrDefault("SKY", "1"));
-
-        return new WeatherDto(
-                UUID.randomUUID(),
-                parseDateTime(firstItem.getBaseDate(), firstItem.getBaseTime()),
-                parseDateTime(firstItem.getFcstDate(), firstItem.getFcstTime()),
-                location,
-                skyStatus,
-                precipitation,
-                humidity,
-                temperature,
-                windSpeed,
-                precipitation.type()
-        );
-    }
-
-    private double parseDouble(String value) {
-        if (value == null || !value.matches("[-+]?\\d*\\.?\\d+([eE][-+]?\\d+)?")) {
-            return 0.0;
-        }
-        return Double.parseDouble(value);
-    }
-
-    /**
-     * 날짜와 시간 문자열을 받아, 한국 시간(KST) 기준으로 해석한 뒤
-     * 세계 표준시(UTC)인 Instant 타입으로 변환합니다.
-     */
-    private Instant parseDateTime(String date, String time) {
-        LocalDate localDate = LocalDate.parse(date, DateTimeFormatter.ofPattern("yyyyMMdd"));
-        LocalTime localTime = LocalTime.parse(time, DateTimeFormatter.ofPattern("HHmm"));
-        return OffsetDateTime.of(localDate, localTime, ZoneOffset.ofHours(9)).toInstant();
-    }
-
-    private SkyStatus mapToSkyStatus(String skyCode) {
-        return switch (skyCode) {
-            case "1" -> SkyStatus.CLEAR;
-            case "3" -> SkyStatus.MOSTLY_CLOUDY;
-            case "4" -> SkyStatus.CLOUDY;
-            default -> SkyStatus.CLEAR;
-        };
-    }
-
-    private PrecipitationType mapToPrecipitationType(String ptyCode) {
-        return switch (ptyCode) {
-            case "1" -> PrecipitationType.RAIN;
-            case "2" -> PrecipitationType.RAIN_SNOW;
-            case "3" -> PrecipitationType.SNOW;
-            case "4" -> PrecipitationType.SHOWER;
-            default -> PrecipitationType.NONE;
-        };
-    }
-
-    private String mapToWindSpeedAsWord(double speed) {
-        if (speed < 4) return "약함";
-        if (speed < 9) return "약간 강함";
-        if (speed < 14) return "강함";
-        return "매우 강함";
     }
 }

--- a/src/main/java/com/codeit/otboo/domain/weather/service/WeatherServiceImpl.java
+++ b/src/main/java/com/codeit/otboo/domain/weather/service/WeatherServiceImpl.java
@@ -1,21 +1,17 @@
+// WeatherServiceImpl.java 파일
+
 package com.codeit.otboo.domain.weather.service;
 
 import com.codeit.otboo.domain.weather.component.LocationConverter;
 import com.codeit.otboo.domain.weather.dto.WeatherDto;
 import com.codeit.otboo.domain.weather.entity.Weather;
-import com.codeit.otboo.domain.weather.entity.vo.HumidityInfo;
-import com.codeit.otboo.domain.weather.entity.vo.PrecipitationInfo;
-import com.codeit.otboo.domain.weather.entity.vo.TemperatureInfo;
-import com.codeit.otboo.domain.weather.entity.vo.WindSpeedInfo;
 import com.codeit.otboo.domain.weather.entity.vo.LocationInfo;
 import com.codeit.otboo.domain.weather.repository.WeatherRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.*;
-import java.util.*;
-import java.util.stream.Collectors;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -27,85 +23,16 @@ public class WeatherServiceImpl implements WeatherService {
     @Override
     @Transactional(readOnly = true)
     public List<WeatherDto> getWeather(double latitude, double longitude) {
-        // 1) 위도/경도를 격자 좌표로 변환
+        // 1. 위도/경도를 격자 좌표로 변환
         LocationInfo loc = locationConverter.toGrid(latitude, longitude);
 
-        // 2) 조회 기준을 '오늘 00:00 (KST)' 로 설정
-        ZoneId zone = ZoneId.of("Asia/Seoul");
-        OffsetDateTime todayStart = LocalDate.now(zone)
-                .atStartOfDay(zone)
-                .toOffsetDateTime();
+        // 2. DB에서 해당 위치의 모든 일별 데이터를 조회
+        List<Weather> dailyWeathers = weatherRepository.findByLocationXAndLocationYOrderByForecastAtAsc(loc.x(), loc.y());
 
-        // 3) 오늘 00시 이후로 저장된 모든 시간별 데이터를 가져와 DTO로 매핑
-        List<WeatherDto> hourly = weatherRepository
-                .findWeathersByLocation(loc.x(), loc.y(), todayStart)
-                .stream()
+        // 3. 조회된 엔티티 목록을 DTO 목록으로 변환하여 반환
+        return dailyWeathers.stream()
                 .map(this::mapToWeatherDto)
                 .toList();
-
-        // 4) LocalDate 단위로 그룹핑
-        Map<LocalDate, List<WeatherDto>> byDate = hourly.stream()
-                .collect(Collectors.groupingBy(w ->
-                        LocalDateTime.ofInstant(w.forecastAt(), zone)
-                                .toLocalDate()
-                ));
-
-        // 5) 일자 순 정렬 후, 각 날짜별 요약 생성
-        List<LocalDate> dates = byDate.keySet().stream()
-                .sorted()
-                .toList();
-
-        List<WeatherDto> summary = new ArrayList<>();
-        Double prevAvgTemp = null;
-        Double prevAvgHum  = null;
-
-        for (LocalDate date : dates) {
-            List<WeatherDto> dayList = byDate.get(date);
-
-            // 발표 시각: 가장 최신 forecastedAt
-            Instant latestForecastedAt = dayList.stream()
-                    .map(WeatherDto::forecastedAt)
-                    .max(Instant::compareTo)
-                    .orElse(Instant.now());
-
-            // 온도·습도·풍속·강수량·강수확률의 평균/최저/최고값 계산
-            double avgTemp = dayList.stream().mapToDouble(d -> d.temperature().current()).average().orElse(0);
-            double minTemp = dayList.stream().mapToDouble(d -> d.temperature().current()).min().orElse(0);
-            double maxTemp = dayList.stream().mapToDouble(d -> d.temperature().current()).max().orElse(0);
-
-            double avgHum = dayList.stream().mapToDouble(d -> d.humidity().current()).average().orElse(0);
-            double avgWind = dayList.stream().mapToDouble(d -> d.windSpeed().speed()).average().orElse(0);
-
-            double avgPrecipAmount = dayList.stream().mapToDouble(d -> d.precipitation().amount()).average().orElse(0);
-            double avgPrecipProb   = dayList.stream().mapToDouble(d -> d.precipitation().probability()).average().orElse(0);
-
-            // 전일 대비 변화량
-            double tempDiff = prevAvgTemp != null ? avgTemp - prevAvgTemp : 0;
-            double humDiff  = prevAvgHum  != null ? avgHum  - prevAvgHum  : 0;
-
-            // 대표값(첫번째)에서 location, skyStatus, asWord, precipitationType 가져오기
-            WeatherDto first = dayList.get(0);
-
-            // 6) 일별 요약 DTO 생성
-            WeatherDto daySummary = new WeatherDto(
-                    UUID.randomUUID(),
-                    latestForecastedAt,
-                    date.atStartOfDay(zone).toInstant(),
-                    first.location(),
-                    first.skyStatus(),
-                    new PrecipitationInfo(first.precipitation().type(), avgPrecipAmount, avgPrecipProb),
-                    new HumidityInfo(avgHum, humDiff),
-                    new TemperatureInfo(avgTemp, minTemp, maxTemp, tempDiff),
-                    new WindSpeedInfo(avgWind, first.windSpeed().asWord()),
-                    first.precipitationType()
-            );
-
-            summary.add(daySummary);
-            prevAvgTemp = avgTemp;
-            prevAvgHum  = avgHum;
-        }
-
-        return summary;
     }
 
     @Override
@@ -114,6 +41,7 @@ public class WeatherServiceImpl implements WeatherService {
         return locationConverter.toGrid(latitude, longitude);
     }
 
+    // 엔티티를 DTO로 변환하는 헬퍼 메서드
     private WeatherDto mapToWeatherDto(Weather w) {
         return new WeatherDto(
                 w.getId(),


### PR DESCRIPTION
## 🧩 이슈 번호

-   close #65

## 📝 설명

기존 날씨 기능의 여러 문제를 해결하고, 데이터 처리 방식의 아키텍처를 전면 개선하여 시스템 안정성과 데이터 정합성을 높였습니다.

### 💣 기존 문제점

-   시간별 날씨 데이터를 그대로 저장하여 DB에 중복 및 불완전한 데이터가 과도하게 쌓였습니다.
-   `min`/`max` 온도, `comparedToDayBefore` 등 핵심 데이터가 `0`으로 저장되는 문제가 발생했습니다.
-   프론트엔드에서 만료된 `weatherId`로 요청 시 `404 에러`가 발생하여 기능 사용이 불가했습니다.
-   데이터 조회 시 실시간으로 집계하는 로직이 비효율적이었고, 다양한 `Exception`이 발생했습니다.

### ✨ 개선 사항

-   Spring Batch의 `ItemProcessor`에서 모든 날씨 데이터를 **날짜별로 집계/계산**하여, 하루에 위치별로 **단 하나의 완성된 데이터만 저장**하도록 로직을 변경했습니다.
-   이를 통해 DB 데이터의 정합성과 일관성을 확보하고, 조회 로직을 단순화하여 전반적인 성능과 안정성을 향상시켰습니다.

## ✅ 주요 변경 사항

-   **`WeatherBatchConfig.java` (핵심 변경)**
    -   API 응답을 날짜별로 그룹화하여 오늘, 내일, 모레의 예보를 각각 별도의 `Weather` 엔티티로 생성합니다.
    -   `TMN`/`TMX` 값이 없는 경우, 시간별 온도(`TMP`)에서 최저/최고 기온을 직접 계산하는 로직을 추가했습니다.
    -   '전일 대비' 값을 배치 내에서 순차적으로 계산하여 모든 날짜의 예보에 정확히 반영되도록 수정했습니다.
    -   기상청 API의 다양한 값 형식(`강수없음`, `2.0mm` 등)을 안전하게 처리하는 숫자 변환 로직을 추가했습니다.
    -   `@StepScope`를 적용하여 배치가 실행될 때마다 최신 DB 상태를 읽도록 수정했습니다.

-   **`WeatherServiceImpl.java`**
    -   실시간 집계 로직을 모두 제거하고, DB에 미리 저장된 완성형 데이터를 단순 조회하여 반환하도록 변경하여 매우 효율적으로 동작합니다.

-   **`FeedServiceImpl.java` & `RecommendationService.java`**
    -   프론트엔드에서 만료된 `weatherId`를 보내더라도, 백엔드가 유연하게 최신 날씨 정보로 대체하여 처리하도록 '자동 복구' 로직을 유지했습니다.

-   **`WeatherRepository.java`**
    -   새로운 배치 및 서비스 로직에 필요한 쿼리 메서드를 추가하고, JPA가 해석하지 못하던 문제를 `Native Query` 또는 명시적 `@Query`로 해결했습니다.

## 🧪 테스트 방법

1.  `weathers` 테이블을 `TRUNCATE`하여 비웁니다.
2.  `POST /api/batch/run-weather-job`을 호출하여 배치를 수동 실행합니다.
3.  `weathers` 테이블을 조회하여, 위치별 & 날짜별로 중복 없이 하나의 데이터가, 모든 필드(최저/최고/전일대비 등)가 채워진 상태로 저장되었는지 확인합니다.
4.  `GET /api/weathers`를 호출하여 정상적으로 데이터가 조회되는지 확인합니다.

## 📸
<img width="1235" height="803" alt="123123" src="https://github.com/user-attachments/assets/9ba17103-b30f-48d0-9aab-000d0012f8b7" />

<img width="693" height="521" alt="캡처" src="https://github.com/user-attachments/assets/5d6c0e7a-cc33-4961-b555-be3d3e8ba993" />



