### PR TITLE
Feat/env separation

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,36 @@
+spring:
+  datasource:
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+    driver-class-name: org.postgresql.Driver
+
+  sql:
+    init:
+      mode: never
+      schema-locations: classpath:schema.sql
+
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+        format_sql: true
+    show-sql: true
+
+  batch:
+    jdbc:
+      initialize-schema: NEVER
+
+api:
+  kma:
+    base-url: "https://apis.data.go.kr/1360000/VilageFcstInfoService_2.0"
+    service-key: "${API_KMA_SERVICE_KEY}"
+  kakao:
+    rest-key: "${API_KAKAO_REST_KEY}"

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,40 @@
+spring:
+  datasource:
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+    driver-class-name: org.postgresql.Driver
+
+  sql:
+    init:
+      mode: never
+      schema-locations: classpath:schema.sql
+
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
+
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+        format_sql: false
+    show-sql: false
+
+  batch:
+    jdbc:
+      initialize-schema: NEVER
+
+api:
+  kma:
+    base-url: "https://apis.data.go.kr/1360000/VilageFcstInfoService_2.0"
+    service-key: "${API_KMA_SERVICE_KEY}"
+  kakao:
+    rest-key: "${API_KAKAO_REST_KEY}"
+
+logging:
+  level:
+    org.springframework.web.reactive.function.client: ERROR

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,52 +2,18 @@ spring:
   application:
     name: otboo
 
-  sql:
-    init:
-      mode: never
-      schema-locations: classpath:schema.sql
-
-  datasource:
-    url: ${DB_URL}
-    username: ${DB_USERNAME}
-    password: ${DB_PASSWORD}
-    driver-class-name: org.postgresql.Driver
-
-
-  data:
-    redis:
-      host: localhost
-      port: 6379
-
-  jpa:
-    hibernate:
-      ddl-auto: validate
-    properties:
-      hibernate:
-        dialect: org.hibernate.dialect.PostgreSQLDialect
-        format_sql: true
-    show-sql: true
+  profiles:
+    active: dev   # 기본 실행 프로필을 dev로 설정
 
   mvc:
     pathmatch:
       matching-strategy: ant_path_matcher
-
-  batch:
-    jdbc:
-      initialize-schema: NEVER
-
-api:
-  kma:
-    base-url: "https://apis.data.go.kr/1360000/VilageFcstInfoService_2.0"
-    service-key: "${API_KMA_SERVICE_KEY}"
-  kakao:
-    rest-key: "${API_KAKAO_REST_KEY}"
 
 logging:
   level:
     org.springframework.web.reactive.function.client: DEBUG
 
 jwt:
-  secret: MySuperSecretJwtKeyThatShouldBeLongEnough123
-  expiration: 600000 # 10? (??? ??)
-  refresh-token-validity-in-ms: 604800000
+  secret: ${JWT_SECRET}
+  expiration: ${JWT_EXPIRATION}
+  refresh-token-validity-in-ms: ${JWT_REFRESH_TOKEN_VALIDITY}


### PR DESCRIPTION
## 🧩 이슈 번호 

  -close #69 


## ✅ 작업 사항
- Spring Profile 기반으로 개발(dev), 운영(prod) 환경 분리

- application.yml에 공통 설정 및 기본 프로필(dev) 적용

- application-dev.yml, application-prod.yml 파일 생성 및 환경별 설정 분리

## 💬 기타 사항
- 환경별로 DB/로그레벨 등 분리 적용됨

- 운영 배포 시 SPRING_PROFILES_ACTIVE로 prod 적용 테스트 필요