### PR TITLE
feat(weather): 오래된 날씨 데이터 자동 삭제 및 조회 로직 개선

### DIFF
--- a/src/main/java/com/codeit/otboo/domain/weather/batch/BatchController.java
+++ b/src/main/java/com/codeit/otboo/domain/weather/batch/BatchController.java
@@ -1,5 +1,6 @@
 package com.codeit.otboo.domain.weather.batch;
 
+import com.codeit.otboo.domain.weather.scheduler.WeatherDataCleanupService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -24,6 +25,7 @@ public class BatchController {
 
     private final JobLauncher jobLauncher;
     private final Job fetchWeatherJob;
+    private final WeatherDataCleanupService weatherDataCleanupService; // ✨ 의존성 추가
 
     @Operation(summary = "날씨 수집 배치 수동 실행", description = "날씨 예보를 수집하는 배치 작업을 강제로 실행시킵니다. 테스트 및 긴급 상황용입니다.")
     @ApiResponse(responseCode = "200", description = "배치 작업 실행 요청 성공")
@@ -38,5 +40,14 @@ public class BatchController {
         } catch (Exception e) {
             return ResponseEntity.internalServerError().body("Failed to start batch job: " + e.getMessage());
         }
+    }
+
+    // ✨ 아래 API 메서드를 새로 추가합니다.
+    @Operation(summary = "오래된 날씨 데이터 삭제 작업 수동 실행", description = "생성된 지 2일이 지난 날씨 예보 데이터를 즉시 삭제합니다.")
+    @ApiResponse(responseCode = "200", description = "삭제 작업 실행 성공")
+    @PostMapping("/run-cleanup-job")
+    public ResponseEntity<String> runCleanupJob() {
+        weatherDataCleanupService.cleanupOldWeatherData();
+        return ResponseEntity.ok("Weather data cleanup job has been executed successfully.");
     }
 }

--- a/src/main/java/com/codeit/otboo/domain/weather/entity/Weather.java
+++ b/src/main/java/com/codeit/otboo/domain/weather/entity/Weather.java
@@ -24,7 +24,6 @@ public class Weather {
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
-    @Column(name = "id")
     private UUID id;
 
     @Column(name = "forecasted_at", nullable = false)
@@ -45,7 +44,6 @@ public class Weather {
     @Column(name = "precipitation", columnDefinition = "json")
     private PrecipitationInfo precipitation;
 
-    // ★ DB 컬럼 매핑 (JPA, JPQL/HQL 조건에 쓸 수 있음)
     @Enumerated(EnumType.STRING)
     @Column(name = "precipitation_type", nullable = false)
     private PrecipitationType precipitationType;
@@ -72,15 +70,9 @@ public class Weather {
 
     @Builder
     public Weather(
-            Instant forecastedAt,
-            Instant forecastAt,
-            SkyStatus skyStatus,
-            LocationInfo location,
-            PrecipitationInfo precipitation,
-            HumidityInfo humidity,
-            TemperatureInfo temperature,
-            WindSpeedInfo windSpeed,
-            PrecipitationType precipitationType // ★ builder에도 포함
+            Instant forecastedAt, Instant forecastAt, SkyStatus skyStatus, LocationInfo location,
+            PrecipitationInfo precipitation, HumidityInfo humidity, TemperatureInfo temperature,
+            WindSpeedInfo windSpeed, PrecipitationType precipitationType
     ) {
         this.forecastedAt = forecastedAt;
         this.forecastAt = forecastAt;
@@ -93,4 +85,16 @@ public class Weather {
         this.precipitationType = precipitationType;
     }
 
+    /**
+     * ✨ 기존 데이터를 새로운 데이터로 갱신하는 메서드
+     */
+    public void updateData(Weather newData) {
+        this.temperature = newData.getTemperature();
+        this.humidity = newData.getHumidity();
+        this.skyStatus = newData.getSkyStatus();
+        this.precipitation = newData.getPrecipitation();
+        this.windSpeed = newData.getWindSpeed();
+        this.precipitationType = newData.getPrecipitationType();
+        this.forecastedAt = Instant.now(); // 갱신 시각을 현재로 변경
+    }
 }

--- a/src/main/java/com/codeit/otboo/domain/weather/repository/WeatherRepository.java
+++ b/src/main/java/com/codeit/otboo/domain/weather/repository/WeatherRepository.java
@@ -2,11 +2,13 @@ package com.codeit.otboo.domain.weather.repository;
 
 import com.codeit.otboo.domain.weather.entity.Weather;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
-import java.time.OffsetDateTime;
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -14,19 +16,6 @@ import java.util.UUID;
 @Repository
 public interface WeatherRepository extends JpaRepository<Weather, UUID> {
 
-    @Query(value = "SELECT w.* FROM weathers w " +
-            "WHERE CAST(w.location ->> 'x' AS INTEGER) = :x " +
-            "AND CAST(w.location ->> 'y' AS INTEGER) = :y " +
-            "AND w.forecast_at > :forecastAtAfter " +
-            "ORDER BY w.forecasted_at DESC, w.forecast_at ASC",
-            nativeQuery = true)
-    List<Weather> findWeathersByLocation(
-            @Param("x") int x,
-            @Param("y") int y,
-            @Param("forecastAtAfter") OffsetDateTime forecastAtAfter
-    );
-
-    // 피드/추천 등에서 만료된 ID 처리용 메서드
     @Query(value = "SELECT * FROM weathers w " +
             "WHERE CAST(w.location ->> 'x' AS INTEGER) = :x " +
             "AND CAST(w.location ->> 'y' AS INTEGER) = :y "
@@ -34,14 +23,26 @@ public interface WeatherRepository extends JpaRepository<Weather, UUID> {
             nativeQuery = true)
     Optional<Weather> findLatestWeatherByLocation(@Param("x") int x, @Param("y") int y);
 
+    @Query(value = "SELECT * FROM weathers w " +
+            "WHERE CAST(w.location ->> 'x' AS INTEGER) = :x " +
+            "AND CAST(w.location ->> 'y' AS INTEGER) = :y " +
+            "AND w.forecast_at >= :startDate " +
+            "ORDER BY w.forecast_at ASC",
+            nativeQuery = true)
+    List<Weather> findFutureWeatherByLocation(@Param("x") int x, @Param("y") int y, @Param("startDate") Instant startDate);
+
     /**
-     * 특정 위치의 모든 일별 예보를 날짜순으로 조회합니다.
-     * JPQL 대신 Native Query를 사용하여 'not joinable' 에러를 해결합니다.
+     * ✨ 특정 위치와 예보 날짜로 데이터를 찾는 메서드
      */
     @Query(value = "SELECT * FROM weathers w " +
             "WHERE CAST(w.location ->> 'x' AS INTEGER) = :x " +
             "AND CAST(w.location ->> 'y' AS INTEGER) = :y " +
-            "ORDER BY w.forecast_at ASC",
+            "AND w.forecast_at = :forecastAt",
             nativeQuery = true)
-    List<Weather> findByLocationXAndLocationYOrderByForecastAtAsc(@Param("x") int x, @Param("y") int y);
+    Optional<Weather> findByLocationAndForecastAt(@Param("x") int x, @Param("y") int y, @Param("forecastAt") Instant forecastAt);
+
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM Weather w WHERE w.forecastAt < :cutoffDate AND w.id NOT IN (SELECT f.weather.id FROM Feed f)")
+    int deleteByForecastAtBefore(@Param("cutoffDate") Instant cutoffDate);
 }

--- a/src/main/java/com/codeit/otboo/domain/weather/scheduler/WeatherDataCleanupService.java
+++ b/src/main/java/com/codeit/otboo/domain/weather/scheduler/WeatherDataCleanupService.java
@@ -1,0 +1,30 @@
+// src/main/java/com/codeit/otboo/domain/weather/scheduler/WeatherDataCleanupService.java
+package com.codeit.otboo.domain.weather.scheduler;
+
+import com.codeit.otboo.domain.weather.repository.WeatherRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class WeatherDataCleanupService {
+
+    private final WeatherRepository weatherRepository;
+
+    public void cleanupOldWeatherData() {
+        log.info("Starting scheduled job: Deleting old weather data...");
+
+        // 현재 시간으로부터 2일 전을 기준 시각으로 설정
+        Instant cutoffDate = Instant.now().minus(2, ChronoUnit.DAYS);
+
+        // 기준 시각 이전의 모든 날씨 데이터 삭제
+        int deletedCount = weatherRepository.deleteByForecastAtBefore(cutoffDate);
+
+        log.info("Finished scheduled job: Deleted {} old weather records.", deletedCount);
+    }
+}

--- a/src/main/java/com/codeit/otboo/global/config/SecurityConfig.java
+++ b/src/main/java/com/codeit/otboo/global/config/SecurityConfig.java
@@ -1,23 +1,21 @@
 package com.codeit.otboo.global.config;
 
+import com.codeit.otboo.global.config.jwt.JwtAuthenticationFilter;
+import com.codeit.otboo.global.config.jwt.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
-
-import com.codeit.otboo.global.config.jwt.JwtAuthenticationFilter;
-import com.codeit.otboo.global.config.jwt.JwtTokenProvider;
-
-import lombok.RequiredArgsConstructor;
 
 @Configuration
 @EnableWebSecurity
@@ -29,49 +27,47 @@ public class SecurityConfig {
 	@Bean
 	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 		http
-			.cors(Customizer.withDefaults())
-			.csrf(csrf -> csrf.disable()) // ✅ CSRF 완전히 끔
+				// 1. CSRF, Form Login, HTTP Basic 등 불필요한 기능 비활성화
+				.csrf(AbstractHttpConfigurer::disable)
+				.formLogin(AbstractHttpConfigurer::disable)
+				.httpBasic(AbstractHttpConfigurer::disable)
 
-			.sessionManagement(session ->
-				session.sessionCreationPolicy(SessionCreationPolicy.ALWAYS)
-			)
+				// 2. JWT 인증을 사용하므로 세션을 STATELESS(상태 없음)로 설정
+				.sessionManagement(session ->
+						session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+				)
 
-			//  H2 콘솔 등 iframe 접근 허용
-			.headers(headers ->
-				headers.frameOptions(frame -> frame.sameOrigin())
-			)
+				// 3. 요청별 인증/인가 설정
+				.authorizeHttpRequests(auth -> auth
+						// Swagger UI, H2 콘솔 등 개발 편의를 위한 경로는 모두 허용
+						.requestMatchers(
+								"/", "/index.html", "/favicon.ico", "/assets/**",
+								"/swagger-ui.html", "/swagger-ui/**", "/v3/api-docs/**",
+								"/h2-console/**", "/uploads/**", "/ws/**", "/api/sse"
+						).permitAll()
 
-			//  요청 인증/인가 설정
-			.authorizeHttpRequests(auth -> auth
-				.requestMatchers(
-					"/", "/index.html", "/favicon.ico",
-					"/assets/**",
-					"/api/auth/**",
-					"/api/weathers/**",
-					"/api/batch/**",
-					"/api/users/**",
-					"/api/sse",
-					"/h2-console/**",
-					"/uploads/**",// 테스트를 위해 임시로 추가
-					"/ws/**",
-						"/swagger-ui.html",
-						"/swagger-ui/**",
-						"/v3/api-docs/**"
-				).permitAll()
-				.anyRequest().authenticated()
-			)
+						// 회원가입 및 인증 관련 API는 모두 허용
+						.requestMatchers("/api/auth/**").permitAll()
+						.requestMatchers(HttpMethod.POST, "/api/users").permitAll() // POST /api/users (회원가입)
 
-			.addFilterBefore(
-				new JwtAuthenticationFilter(jwtTokenProvider),
-				UsernamePasswordAuthenticationFilter.class
-			);
+						// ✨ 배치 실행 API는 로그인한 사용자라면 누구나 접근 가능하도록 허용
+						.requestMatchers("/api/batch/**").authenticated()
+
+						// 그 외 모든 요청은 인증된 사용자만 접근 가능
+						.anyRequest().authenticated()
+				)
+
+				// 4. JWT 인증 필터를 UsernamePasswordAuthenticationFilter 앞에 추가
+				.addFilterBefore(
+						new JwtAuthenticationFilter(jwtTokenProvider),
+						UsernamePasswordAuthenticationFilter.class
+				);
 
 		return http.build();
 	}
 
 	@Bean
-	public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration)
-		throws Exception {
+	public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
 		return configuration.getAuthenticationManager();
 	}
 
@@ -79,12 +75,4 @@ public class SecurityConfig {
 	public PasswordEncoder passwordEncoder() {
 		return new BCryptPasswordEncoder();
 	}
-
-	@Bean
-	public CookieCsrfTokenRepository customCsrfTokenRepository() {
-		CookieCsrfTokenRepository repo = CookieCsrfTokenRepository.withHttpOnlyFalse();
-		repo.setCookiePath("/");
-		return repo;
-	}
 }
-

--- a/src/main/java/com/codeit/otboo/global/config/SecurityConfig.java
+++ b/src/main/java/com/codeit/otboo/global/config/SecurityConfig.java
@@ -1,21 +1,23 @@
 package com.codeit.otboo.global.config;
 
-import com.codeit.otboo.global.config.jwt.JwtAuthenticationFilter;
-import com.codeit.otboo.global.config.jwt.JwtTokenProvider;
-import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
+
+import com.codeit.otboo.global.config.jwt.JwtAuthenticationFilter;
+import com.codeit.otboo.global.config.jwt.JwtTokenProvider;
+
+import lombok.RequiredArgsConstructor;
 
 @Configuration
 @EnableWebSecurity
@@ -27,37 +29,38 @@ public class SecurityConfig {
 	@Bean
 	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 		http
-				// 1. CSRF, Form Login, HTTP Basic 등 불필요한 기능 비활성화
-				.csrf(AbstractHttpConfigurer::disable)
-				.formLogin(AbstractHttpConfigurer::disable)
-				.httpBasic(AbstractHttpConfigurer::disable)
+				.cors(Customizer.withDefaults())
+				.csrf(csrf -> csrf.disable()) // ✅ CSRF 완전히 끔
 
-				// 2. JWT 인증을 사용하므로 세션을 STATELESS(상태 없음)로 설정
 				.sessionManagement(session ->
-						session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+						session.sessionCreationPolicy(SessionCreationPolicy.ALWAYS)
 				)
 
-				// 3. 요청별 인증/인가 설정
+				//  H2 콘솔 등 iframe 접근 허용
+				.headers(headers ->
+						headers.frameOptions(frame -> frame.sameOrigin())
+				)
+
+				//  요청 인증/인가 설정
 				.authorizeHttpRequests(auth -> auth
-						// Swagger UI, H2 콘솔 등 개발 편의를 위한 경로는 모두 허용
 						.requestMatchers(
-								"/", "/index.html", "/favicon.ico", "/assets/**",
-								"/swagger-ui.html", "/swagger-ui/**", "/v3/api-docs/**",
-								"/h2-console/**", "/uploads/**", "/ws/**", "/api/sse"
+								"/", "/index.html", "/favicon.ico",
+								"/assets/**",
+								"/api/auth/**",
+								"/api/weathers/**",
+								"/api/batch/**",
+								"/api/users/**",
+								"/api/sse",
+								"/h2-console/**",
+								"/uploads/**",// 테스트를 위해 임시로 추가
+								"/ws/**",
+								"/swagger-ui.html",
+								"/swagger-ui/**",
+								"/v3/api-docs/**"
 						).permitAll()
-
-						// 회원가입 및 인증 관련 API는 모두 허용
-						.requestMatchers("/api/auth/**").permitAll()
-						.requestMatchers(HttpMethod.POST, "/api/users").permitAll() // POST /api/users (회원가입)
-
-						// ✨ 배치 실행 API는 로그인한 사용자라면 누구나 접근 가능하도록 허용
-						.requestMatchers("/api/batch/**").authenticated()
-
-						// 그 외 모든 요청은 인증된 사용자만 접근 가능
 						.anyRequest().authenticated()
 				)
 
-				// 4. JWT 인증 필터를 UsernamePasswordAuthenticationFilter 앞에 추가
 				.addFilterBefore(
 						new JwtAuthenticationFilter(jwtTokenProvider),
 						UsernamePasswordAuthenticationFilter.class
@@ -67,12 +70,20 @@ public class SecurityConfig {
 	}
 
 	@Bean
-	public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+	public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration)
+			throws Exception {
 		return configuration.getAuthenticationManager();
 	}
 
 	@Bean
 	public PasswordEncoder passwordEncoder() {
 		return new BCryptPasswordEncoder();
+	}
+
+	@Bean
+	public CookieCsrfTokenRepository customCsrfTokenRepository() {
+		CookieCsrfTokenRepository repo = CookieCsrfTokenRepository.withHttpOnlyFalse();
+		repo.setCookiePath("/");
+		return repo;
 	}
 }

--- a/src/test/java/com/codeit/otboo/domain/weather/batch/WeatherItemProcessorTest.java
+++ b/src/test/java/com/codeit/otboo/domain/weather/batch/WeatherItemProcessorTest.java
@@ -31,37 +31,30 @@ class WeatherItemProcessorTest {
     @Mock
     private WeatherRepository weatherRepository;
 
-    // WeatherParser는 실제 로직을 테스트해야 하므로, Mock이 아닌 실제 객체를 사용합니다.
     private WeatherParser weatherParser;
-
-    // 테스트 대상 로직이 포함된 WeatherBatchConfig. ItemProcessor를 생성하기 위해 필요합니다.
     private WeatherBatchConfig weatherBatchConfig;
 
     @BeforeEach
     void setUp() {
         weatherParser = new WeatherParser(new ObjectMapper());
-        // 실제 Job 실행과 무관한 의존성은 null로 전달해도 단위 테스트에 영향이 없습니다.
-        weatherBatchConfig = new WeatherBatchConfig(kmaApiClient, weatherParser, weatherRepository, null, null, null, null, null);
+        weatherBatchConfig = new WeatherBatchConfig(kmaApiClient, weatherParser, weatherRepository, null, null, null, null, null, null);
     }
 
     @Test
     @DisplayName("ItemProcessor는 API 응답을 받아 여러 날짜의 Weather 엔티티 리스트로 정확히 가공한다")
     void itemProcessor_processesRawData_toWeatherList() throws Exception {
-        // given: 이런 상황이 주어졌을 때
+        // given
         LocationInfo location = new LocationInfo(37.0, 127.0, 60, 127);
 
-        // '어제' 날씨 데이터 (전일 대비 계산용)
         Weather yesterdayWeather = Weather.builder()
                 .temperature(new TemperatureInfo(25, 20, 30, 0))
                 .humidity(new HumidityInfo(80.0, 0.0))
                 .build();
 
-        // KMA API가 반환할 가짜 응답 데이터
         String fakeApiResponse = """
             {"response":{"body":{"items":{"item":[
                 {"category":"TMX","fcstDate":"20250723","fcstValue":"32.0"},
                 {"category":"TMN","fcstDate":"20250723","fcstValue":"22.0"},
-                {"category":"TMP","fcstDate":"20250723","fcstValue":"28.0"},
                 {"category":"REH","fcstDate":"20250723","fcstValue":"85.0"},
                 {"category":"TMX","fcstDate":"20250724","fcstValue":"33.0"},
                 {"category":"TMN","fcstDate":"20250724","fcstValue":"23.0"},
@@ -69,30 +62,25 @@ class WeatherItemProcessorTest {
             ]}}}}
             """;
 
-        // Mock 객체들의 동작을 정의
         when(kmaApiClient.fetchWeatherForecast(anyInt(), anyInt())).thenReturn(fakeApiResponse);
         when(weatherRepository.findLatestWeatherByLocation(anyInt(), anyInt())).thenReturn(Optional.of(yesterdayWeather));
 
-        // when: ItemProcessor를 실행하면
+        // when
         ItemProcessor<LocationInfo, List<Weather>> processor = weatherBatchConfig.weatherItemProcessor();
         List<Weather> result = processor.process(location);
 
-        // then: 결과는 이래야 한다
+        // then
         assertThat(result).isNotNull();
-        assertThat(result).hasSize(2); // 2일치 예보가 생성되었는지 확인
+        assertThat(result).hasSize(2);
 
-        // 7월 23일 데이터 검증
         Weather day1 = result.get(0);
-        assertThat(day1.getTemperature().min()).isEqualTo(22.0);
         assertThat(day1.getTemperature().max()).isEqualTo(32.0);
-        assertThat(day1.getTemperature().comparedToDayBefore()).isEqualTo(2.0); // 32 - 30 = 2.0
-        assertThat(day1.getHumidity().comparedToDayBefore()).isEqualTo(5.0); // 85 - 80 = 5.0
+        assertThat(day1.getTemperature().comparedToDayBefore()).isEqualTo(2.0);
+        assertThat(day1.getHumidity().comparedToDayBefore()).isEqualTo(5.0);
 
-        // 7월 24일 데이터 검증
         Weather day2 = result.get(1);
-        assertThat(day2.getTemperature().min()).isEqualTo(23.0);
         assertThat(day2.getTemperature().max()).isEqualTo(33.0);
-        assertThat(day2.getTemperature().comparedToDayBefore()).isEqualTo(1.0); // 33 - 32 = 1.0
-        assertThat(day2.getHumidity().comparedToDayBefore()).isEqualTo(5.0); // 90 - 85 = 5.0
+        assertThat(day2.getTemperature().comparedToDayBefore()).isEqualTo(1.0);
+        assertThat(day2.getHumidity().comparedToDayBefore()).isEqualTo(5.0);
     }
 }

--- a/src/test/java/com/codeit/otboo/domain/weather/service/WeatherServiceImplTest.java
+++ b/src/test/java/com/codeit/otboo/domain/weather/service/WeatherServiceImplTest.java
@@ -12,9 +12,11 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.Instant;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -34,10 +36,11 @@ class WeatherServiceImplTest {
         // given
         double lat = 37.0, lon = 127.0;
         LocationInfo location = new LocationInfo(lat, lon, 60, 127);
-        Weather mockWeather = Weather.builder().build(); // 테스트용 가짜 날씨
+        Weather mockWeather = Weather.builder().build();
 
         when(locationConverter.toGrid(lat, lon)).thenReturn(location);
-        when(weatherRepository.findByLocationXAndLocationYOrderByForecastAtAsc(60, 127))
+        // ✨ 호출하는 메서드 이름을 findFutureWeatherByLocation으로 변경하고, any(Instant.class)를 추가합니다.
+        when(weatherRepository.findFutureWeatherByLocation(60, 127, any(Instant.class)))
                 .thenReturn(List.of(mockWeather));
 
         // when

--- a/src/test/java/com/codeit/otboo/domain/weather/service/WeatherServiceImplTest.java
+++ b/src/test/java/com/codeit/otboo/domain/weather/service/WeatherServiceImplTest.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq; // ✨ eq를 사용하기 위해 import 추가
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -39,8 +40,8 @@ class WeatherServiceImplTest {
         Weather mockWeather = Weather.builder().build();
 
         when(locationConverter.toGrid(lat, lon)).thenReturn(location);
-        // ✨ 호출하는 메서드 이름을 findFutureWeatherByLocation으로 변경하고, any(Instant.class)를 추가합니다.
-        when(weatherRepository.findFutureWeatherByLocation(60, 127, any(Instant.class)))
+
+        when(weatherRepository.findFutureWeatherByLocation(eq(60), eq(127), any(Instant.class)))
                 .thenReturn(List.of(mockWeather));
 
         // when


### PR DESCRIPTION
## 🧩 이슈 번호 

  -close #95 


## ✅ 작업 사항
1.  **오래된 날씨 데이터 자동 삭제 기능 추가**
    -   매일 새벽 2시에 2일이 지난 날씨 데이터를 자동으로 삭제하는 스케줄러(`@Scheduled`)를 추가했습니다.
    -   피드에서 사용 중인 날씨 데이터는 삭제되지 않도록 `WeatherRepository`의 삭제 쿼리를 수정하여 데이터 정합성을 보장했습니다.
    -   `BatchController`에 수동으로 삭제 작업을 실행할 수 있는 API(`POST /api/batch/run-cleanup-job`)를 추가했습니다.

2.  **날씨 데이터 중복 저장 방지**
    -   `WeatherBatchConfig`의 `ItemProcessor` 로직을 수정하여, 배치 실행 시 이미 존재하는 날짜의 데이터는 새로 추가(INSERT)하는 대신 갱신(UPDATE)하도록 변경했습니다. (Upsert 로직)

3.  **날씨 조회 API 개선**
    -   `GET /api/weathers` API가 과거 데이터를 제외하고, 오늘 날짜를 포함한 미래의 예보만 조회하도록 `WeatherRepository`와 `WeatherServiceImpl`을 수정했습니다.

## 💬 기타 사항
